### PR TITLE
Re-designed PINGREQ sending interval management.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-# 0.5.1 undetermined
+# 0.6.0 undetermined
+
+## Breaking changes
+
+* Re-designed PINGREQ sending interval management. #35
+  * GenericConnection::set_pingreq_send_interval() duration parameter becomes `Option<u64>`.
+  * Prioritize PINGREQ sending interval settings.
+     1. User setting by GenericConnection::set_pingreq_send_interval().
+     2. ServerKeepAlive Property value in received CONNACK packet.
+     3. KeepAlive(default 0) value in sent CONNECT packet.
+
+## Other updates
 
 * Fix PINGRESP receiving timeout timer management. #34
 * Refine error handling. #32

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt-protocol-core"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 authors = ["Takatoshi Kondo <redboltz@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-mqtt-protocol-core = "0.5.1"
+mqtt-protocol-core = "0.6.0"
 ```
 
 ### No-std Support
@@ -47,7 +47,7 @@ For `no_std` environments (embedded systems), disable the default `std` feature:
 
 ```toml
 [dependencies]
-mqtt-protocol-core = { version = "0.5.1", default-features = false }
+mqtt-protocol-core = { version = "0.6.0", default-features = false }
 ```
 
 Caveats:
@@ -64,15 +64,15 @@ The library supports several optional features that can be enabled/disabled as n
 ```toml
 # Enable tracing support (independent of std)
 [dependencies]
-mqtt-protocol-core = { version = "0.5.1", default-features = false, features = ["tracing"] }
+mqtt-protocol-core = { version = "0.6.0", default-features = false, features = ["tracing"] }
 
 # Use with std but without tracing
 [dependencies]
-mqtt-protocol-core = { version = "0.5.1", default-features = false, features = ["std"] }
+mqtt-protocol-core = { version = "0.6.0", default-features = false, features = ["std"] }
 
 # Full-featured (std + tracing)
 [dependencies]
-mqtt-protocol-core = { version = "0.5.1", features = ["tracing"] }
+mqtt-protocol-core = { version = "0.6.0", features = ["tracing"] }
 ```
 
 ### Small String Optimization (SSO) Features
@@ -87,11 +87,11 @@ This crate provides SSO features to optimize memory usage for small string and b
 ```toml
 # Use specific SSO optimization level
 [dependencies]
-mqtt-protocol-core = { version = "0.5.1", features = ["sso-lv10"] }
+mqtt-protocol-core = { version = "0.6.0", features = ["sso-lv10"] }
 
 # Combine with other features
 [dependencies]
-mqtt-protocol-core = { version = "0.5.1", features = ["std", "sso-lv20", "tracing"] }
+mqtt-protocol-core = { version = "0.6.0", features = ["std", "sso-lv20", "tracing"] }
 ```
 
 #### ⚠️ **Important: Feature Flag Propagation Requirement**
@@ -110,7 +110,7 @@ When your crate depends on `mqtt-protocol-core` and is used by other crates or a
 ```toml
 # Your crate's Cargo.toml
 [dependencies]
-mqtt-protocol-core = { version = "0.5.1", features = ["sso-lv10"] }
+mqtt-protocol-core = { version = "0.6.0", features = ["sso-lv10"] }
 
 [features]
 # You MUST re-export ALL SSO features to allow downstream configuration

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! mqtt-protocol-core = { version = "0.5.1", default-features = false }
+//! mqtt-protocol-core = { version = "0.6.0", default-features = false }
 //! ```
 //!
 //! **No-std usage example:**
@@ -173,15 +173,15 @@
 //! ```toml
 //! # Enable tracing support (independent of std)
 //! [dependencies]
-//! mqtt-protocol-core = { version = "0.5.1", default-features = false, features = ["tracing"] }
+//! mqtt-protocol-core = { version = "0.6.0", default-features = false, features = ["tracing"] }
 //!
 //! # Use with std but without tracing overhead
 //! [dependencies]
-//! mqtt-protocol-core = { version = "0.5.1", default-features = false, features = ["std"] }
+//! mqtt-protocol-core = { version = "0.6.0", default-features = false, features = ["std"] }
 //!
 //! # Full-featured (std + tracing)
 //! [dependencies]
-//! mqtt-protocol-core = { version = "0.5.1", features = ["tracing"] }
+//! mqtt-protocol-core = { version = "0.6.0", features = ["tracing"] }
 //! ```
 //!
 //! ### Small String Optimization (SSO) Features
@@ -208,11 +208,11 @@
 //! ```toml
 //! # Use specific SSO optimization level
 //! [dependencies]
-//! mqtt-protocol-core = { version = "0.5.1", features = ["sso-lv10"] }
+//! mqtt-protocol-core = { version = "0.6.0", features = ["sso-lv10"] }
 //!
 //! # Combine with other features
 //! [dependencies]
-//! mqtt-protocol-core = { version = "0.5.1", features = ["std", "sso-lv20", "tracing"] }
+//! mqtt-protocol-core = { version = "0.6.0", features = ["std", "sso-lv20", "tracing"] }
 //! ```
 //!
 //! #### ⚠️ **Critical: SSO Feature Flag Propagation**
@@ -234,7 +234,7 @@
 //! ```toml
 //! # Your crate's Cargo.toml
 //! [dependencies]
-//! mqtt-protocol-core = { version = "0.5.1", features = ["sso-lv10"] }
+//! mqtt-protocol-core = { version = "0.6.0", features = ["sso-lv10"] }
 //!
 //! [features]
 //! # MANDATORY: Re-export ALL SSO features to allow downstream configuration

--- a/tests/connection-core-cancel-timer.rs
+++ b/tests/connection-core-cancel-timer.rs
@@ -1,0 +1,59 @@
+// MIT License
+//
+// Copyright (c) 2025 Takatoshi Kondo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+use mqtt_protocol_core::mqtt;
+mod common;
+use common::*;
+
+#[test]
+fn v5_0_client_send_connect_keep_alive() {
+    common::init_tracing();
+    let mut con = mqtt::Connection::<mqtt::role::Client>::new(mqtt::Version::V5_0);
+    con.set_pingreq_send_interval(Some(3000));
+    con.set_pingresp_recv_timeout(Some(1000));
+    v5_0_client_establish_connection(&mut con);
+
+    let packet = mqtt::packet::v5_0::Pingreq::new();
+    let _events = con.checked_send(packet);
+
+    let events = con.notify_closed();
+    assert_eq!(events.len(), 2);
+
+    if let mqtt::connection::GenericEvent::RequestTimerCancel(kind) = events[0] {
+        assert_eq!(kind, mqtt::connection::TimerKind::PingreqSend);
+    } else {
+        assert!(
+            false,
+            "Expected RequestTimerCancel event with PingreqSend, but got: {:?}",
+            events[1]
+        );
+    }
+
+    if let mqtt::connection::GenericEvent::RequestTimerCancel(kind) = events[1] {
+        assert_eq!(kind, mqtt::connection::TimerKind::PingrespRecv);
+    } else {
+        assert!(
+            false,
+            "Expected RequestTimerCancel event with PingrespRecv, but got: {:?}",
+            events[1]
+        );
+    }
+}

--- a/tests/connection-core-keep-alive.rs
+++ b/tests/connection-core-keep-alive.rs
@@ -265,7 +265,7 @@ fn client_receive_connack_server_keep_alive_prop_0to1() {
     // Check RequestTimerReset event
     if let mqtt::connection::Event::RequestTimerReset { kind, duration_ms } = &events[0] {
         assert_eq!(*kind, mqtt::connection::TimerKind::PingreqSend);
-        assert_eq!(*duration_ms, 1500);
+        assert_eq!(*duration_ms, 1000);
     } else {
         panic!("Expected RequestTimerReset event, got: {:?}", events[0]);
     }


### PR DESCRIPTION
  * GenericConnection::set_pingreq_send_interval() duration parameter becomes `Option<u64>`.
  * Prioritize PINGREQ sending interval settings.
     1. User setting by GenericConnection::set_pingreq_send_interval()
     2. ServerKeepAlive Property value in received CONNACK packet. 3. KeepAlive(default 0) value in sent CONNECT packet.