### PR TITLE
Avoid duplicate libraries when building with `-Zbuild-std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,6 @@ once_cell = { version = "1.18", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 indexmap = { version = "2", default-features = false }
 hashbrown = { version = "0.15", default-features = false, features = [
-    "alloc",
-    "core",
     "inline-more",
 ] }
 num_enum = { version = "0.7", default-features = false }


### PR DESCRIPTION
These hashbrown features are intended to be used only when building that library as part of `std` from inside the rustc workspace. Normally, if these features are enabled outside of a compiler build, the crates.io versions of `rustc-std-workspace-core` and `rustc-std-workspace-alloc` harmlessly wrap the `core` and `alloc` crates from the compiler's sysroot. But when using `-Zbuild-std`, they create a second conflicting copy of `core` and `alloc` inside the local workspace:

```
$ cargo build --no-default-features -Z build-std=core,alloc
   Compiling hashbrown v0.15.5
error[E0464]: multiple candidates for `rmeta` dependency `core` found
  |
  = note: candidate #1: mqtt-protocol-core/target/debug/deps/libcore-63212f86292bc9b2.rmeta
  = note: candidate #2: mqtt-protocol-core/target/debug/deps/librustc_std_workspace_core-87d6eaf43c4c124e.rmeta

error[E0464]: multiple candidates for `rmeta` dependency `alloc` found
  --> hashbrown-0.15.5/src/lib.rs:64:1
   |
64 | extern crate alloc;
   | ^^^^^^^^^^^^^^^^^^^
   |
   = note: candidate #1: mqtt-protocol-core/target/debug/deps/liballoc-72d6465b9ee82117.rmeta
   = note: candidate #2: mqtt-protocol-core/target/debug/deps/librustc_std_workspace_alloc-a3fbb36e3ffcf55c.rmeta
```