### PR TITLE
Optionally derive defmt::Format for some types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ enum_dispatch = "0.3"
 foldhash = { version = "0.2.0", default-features = false }
 
 # logging
+defmt = { version = "1.0.1", default-features = false, optional = true }
 tracing = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/src/mqtt/connection/event.rs
+++ b/src/mqtt/connection/event.rs
@@ -33,6 +33,7 @@ use crate::mqtt::result_code::MqttError;
 /// This enum defines the different kinds of timers used in MQTT protocol operations.
 /// Each timer serves a specific purpose in maintaining connection health and protocol compliance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TimerKind {
     /// Timer for sending PINGREQ packets
     ///

--- a/src/mqtt/connection/version.rs
+++ b/src/mqtt/connection/version.rs
@@ -52,6 +52,7 @@
 /// }
 /// ```
 #[derive(PartialEq, Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Version {
     /// Version to be determined by incoming CONNECT packet
     ///

--- a/src/mqtt/packet/packet_type.rs
+++ b/src/mqtt/packet/packet_type.rs
@@ -42,6 +42,7 @@ use serde::{Deserialize, Serialize};
 /// assert_eq!(packet_type.as_str(), "connect");
 /// ```
 #[derive(Deserialize, PartialEq, Eq, Copy, Clone, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum PacketType {
     /// Client connection request packet
@@ -98,6 +99,7 @@ pub enum PacketType {
 /// assert_eq!(header.packet_type(), PacketType::Connect);
 /// ```
 #[derive(Deserialize, PartialEq, Eq, Copy, Clone, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum FixedHeader {
     /// CONNECT packet header (0x10)

--- a/src/mqtt/packet/property.rs
+++ b/src/mqtt/packet/property.rs
@@ -60,6 +60,7 @@ use std::io::IoSlice;
 /// assert_eq!(property_id.as_str(), "message_expiry_interval");
 /// ```
 #[derive(Deserialize, PartialEq, Eq, Copy, Clone, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum PropertyId {
     /// Indicates the format of the payload in PUBLISH packets (0=binary, 1=UTF-8)
@@ -224,6 +225,7 @@ impl fmt::Debug for PropertyId {
 /// assert_eq!(format as u8, 1);
 /// ```
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum PayloadFormat {
     /// Payload is unspecified bytes (binary data)

--- a/src/mqtt/packet/qos.rs
+++ b/src/mqtt/packet/qos.rs
@@ -71,6 +71,7 @@ use serde::{Deserialize, Serialize};
 #[derive(
     Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, TryFromPrimitive,
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum Qos {
     /// QoS level 0: At most once delivery

--- a/src/mqtt/packet/retain_handling.rs
+++ b/src/mqtt/packet/retain_handling.rs
@@ -70,6 +70,7 @@ use serde::{Deserialize, Serialize};
 #[derive(
     Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, TryFromPrimitive,
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum RetainHandling {
     /// Send retained messages at the time of the subscribe

--- a/src/mqtt/result_code.rs
+++ b/src/mqtt/result_code.rs
@@ -26,6 +26,7 @@ use num_enum::TryFromPrimitive;
 use serde::{Serialize, Serializer};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u16)]
 pub enum MqttError {
     // MQTT protocol based error
@@ -210,6 +211,7 @@ impl core::convert::TryFrom<u8> for MqttError {
 
 /// MQTT v3.1.1 Connect Return Code
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum ConnectReturnCode {
     Accepted = 0,                    // Connection accepted (not an error)
@@ -254,6 +256,7 @@ impl Serialize for ConnectReturnCode {
 
 /// MQTT v3.1.1 SUBACK Return Code
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum SubackReturnCode {
     SuccessMaximumQos0 = 0x00, // Success with QoS0 (not an error)
@@ -297,6 +300,7 @@ impl Serialize for SubackReturnCode {
 
 /// MQTT v5.0 Connect Reason Code (used in CONNACK)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum ConnectReasonCode {
     Success = 0x00,                     // Success (not an error)
@@ -370,6 +374,7 @@ impl From<ConnectReasonCode> for MqttError {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum DisconnectReasonCode {
     NormalDisconnection = 0x00,
@@ -501,6 +506,7 @@ impl From<MqttError> for DisconnectReasonCode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum SubackReasonCode {
     GrantedQos0 = 0x00,
@@ -566,6 +572,7 @@ impl From<SubackReasonCode> for MqttError {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum UnsubackReasonCode {
     Success = 0x00,
@@ -618,6 +625,7 @@ impl From<UnsubackReasonCode> for MqttError {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum PubackReasonCode {
     Success = 0x00,
@@ -674,6 +682,7 @@ impl From<PubackReasonCode> for MqttError {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum PubrecReasonCode {
     Success = 0x00,
@@ -729,6 +738,7 @@ impl From<PubrecReasonCode> for MqttError {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum PubrelReasonCode {
     Success = 0x00,
@@ -771,6 +781,7 @@ impl From<PubrelReasonCode> for MqttError {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum PubcompReasonCode {
     Success = 0x00,
@@ -813,6 +824,7 @@ impl From<PubcompReasonCode> for MqttError {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum AuthReasonCode {
     Success = 0x00,


### PR DESCRIPTION
This allows them to be referenced in format strings when using the defmt logging framework. Currently this only covers the smaller enums for things like packet headers and error codes.