### PR TITLE
Disconnect when receiving an unsuccessful CONNACK

### DIFF
--- a/src/mqtt/connection/core.rs
+++ b/src/mqtt/connection/core.rs
@@ -2611,6 +2611,8 @@ where
                     } else {
                         self.clear_store_related();
                     }
+                } else {
+                    events.push(GenericEvent::RequestClose);
                 }
                 events.push(GenericEvent::NotifyPacketReceived(
                     GenericPacket::V3_1_1Connack(packet),
@@ -2683,6 +2685,8 @@ where
                     } else {
                         self.clear_store_related();
                     }
+                } else {
+                    events.push(GenericEvent::RequestClose);
                 }
                 events.push(GenericEvent::NotifyPacketReceived(
                     GenericPacket::V5_0Connack(packet),


### PR DESCRIPTION
MQTT v3.1.1 requires: "If a server sends a CONNACK packet containing a non-zero return code it MUST then close the Network Connection [MQTT-3.2.2-5]."

MQTT v5.0 requires: "If a Server sends a CONNACK packet containing a Reason code of 128 or greater it MUST then close the Network Connection [MQTT-3.2.2-7]."

Since the network connection is guaranteed to be closed from the server side, the library can detect this and request to close the socket on the client side.

The user could handle this by separately parsing the `NotifyPacketReceived(Connack)` event, but this seems like a reasonable convenience to provide for clients that don't care about the reason code, if you agree. This ordering was simplest to implement, but may be the `RequestClose` event should come after the `NotifyPacketReceived`?