### PR TITLE
Implement `core::error::Error` for `MqttError`

### DIFF
--- a/src/mqtt/result_code.rs
+++ b/src/mqtt/result_code.rs
@@ -83,6 +83,8 @@ pub enum MqttError {
     InvalidQos = 0x018D,
 }
 
+impl core::error::Error for MqttError {}
+
 // Implement mapping from UninitializedFieldError to MqttError
 impl From<UninitializedFieldError> for MqttError {
     fn from(_: UninitializedFieldError) -> Self {


### PR DESCRIPTION
This one-liner PR provides a trivial `core::error::Error` implementation for `MqttError`. The advantage of implementing the `Error` trait for `MqttError` is that it makes the type compatible with various error handling libraries, such as [anyhow](https://docs.rs/anyhow/latest/anyhow/) and [thiserror](https://docs.rs/thiserror/latest/thiserror/).