### PR TITLE
Clean up store when publish cannot be sent

### DIFF
--- a/src/mqtt/connection/core.rs
+++ b/src/mqtt/connection/core.rs
@@ -1644,6 +1644,7 @@ where
                 if let Some(packet_id) = packet_id_opt {
                     if self.pid_man.is_used_id(packet_id) {
                         self.pid_man.release_id(packet_id);
+                        self.store.erase_publish(packet_id);
                         events.push(GenericEvent::NotifyPacketIdReleased(packet_id));
                     }
                 }
@@ -1665,6 +1666,7 @@ where
                 if let Some(packet_id) = packet_id_opt {
                     if self.pid_man.is_used_id(packet_id) {
                         self.pid_man.release_id(packet_id);
+                        self.store.erase_publish(packet_id);
                         events.push(GenericEvent::NotifyPacketIdReleased(packet_id));
                     }
                 }
@@ -1709,6 +1711,7 @@ where
                     if let Some(packet_id) = packet_id_opt {
                         if self.pid_man.is_used_id(packet_id) {
                             self.pid_man.release_id(packet_id);
+                            self.store.erase_publish(packet_id);
                             events.push(GenericEvent::NotifyPacketIdReleased(packet_id));
                         }
                     }


### PR DESCRIPTION
If the publish packet has been added to the store, it needs to be removed again if an error prevents it from being sent.
Otherwise the packet_id, which has been released, may be used again for a next publish packet,
which will cause a `PacketIdentifierConflict` when trying to add that to the store.
This in turn causes a panic, since `unwrap` is used when adding the packet to the store.

I ran into this issue for the `ReceiveMaximumExceeded` case.